### PR TITLE
Added localhost redirect option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.html",
   "scripts": {
-    "dev": "node_modules/.bin/webpack-dev-server --content-base ."
+    "dev": "node_modules/.bin/webpack-dev-server --content-base ." 
   },
   "author": "",
   "license": "ISC",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,8 @@ const path = require('path');
 
 const BUILD_DIR = path.resolve(__dirname, 'client/public');
 const APP_DIR = path.resolve(__dirname, 'client');
+// Redirect to localhost if the REDIRECT variable is set
+const REDIRECT = process.env.REDIRECT ? 'http://localhost:9009' : 'http://52.52.22.4';
 
 const config = {
   entry: './app/routes.jsx',
@@ -14,11 +16,11 @@ const config = {
   devServer: {
     proxy: {
       '/api/**': {
-        target: 'http://52.52.22.4',
+        target: REDIRECT, 
         secure: false
       },
       '/auth/**': {
-        target: 'http://52.52.22.4',
+        target: REDIRECT,
         secure: false
       }
     },


### PR DESCRIPTION
If you set the REDIRECT environment variable, client will now run with api calls proxied to localhost:9009
